### PR TITLE
Fixing a weird issue...

### DIFF
--- a/NavUtilities continued/NavUtilLib/AnalogGauges.cs
+++ b/NavUtilities continued/NavUtilLib/AnalogGauges.cs
@@ -193,7 +193,7 @@ namespace NavUtilLib.Analog
 
             rwyLabel.SetText(NavUtilLib.GlobalVariables.FlightData.currentBodyRunways[NavUtilLib.GlobalVariables.FlightData.rwyIdx].shortID);
 
-			NavUtilLib.GlobalVariables.Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(GlobalVariables.Settings.getAudioPath() + "click"));
+			NavUtilLib.GlobalVariables.Audio.PlayClick();
         }
 
         private void OnCrsBtnClick()
@@ -207,7 +207,7 @@ namespace NavUtilLib.Analog
 
             crsKnob.localRotation = crsKnobInit * Quaternion.AngleAxis(((float)NavUtilLib.GlobalVariables.FlightData.gsIdx / (float)NavUtilLib.GlobalVariables.FlightData.gsList.Count()) * 360, Vector3.forward);
 
-			NavUtilLib.GlobalVariables.Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(GlobalVariables.Settings.getAudioPath() + "click"));
+			NavUtilLib.GlobalVariables.Audio.PlayClick();
         }
 
         private void RunOnce()

--- a/NavUtilities continued/NavUtilLib/GlobalV_DisplayData.cs
+++ b/NavUtilities continued/NavUtilLib/GlobalV_DisplayData.cs
@@ -193,15 +193,15 @@ namespace NavUtilLib
                         switch (bcnCode)
                         {
                             case 1:
-						var.Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(GlobalVariables.Settings.getAudioPath() + "outer"));
+                                var.Audio.Instance.PlayOuter();
                                 break;
 
                             case 2:
-						var.Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(GlobalVariables.Settings.getAudioPath() + "middle"));
+                                var.Audio.Instance.PlayMiddle();
                                 break;
 
                             case 3:
-						var.Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(GlobalVariables.Settings.getAudioPath() + "inner"));
+                                var.Audio.Instance.PlayInner();
                                 break;
 
                             default:
@@ -234,7 +234,7 @@ namespace NavUtilLib
                             break;
 
                         default:
-                            var.Audio.markerAudio.Stop();
+                            var.Audio.Instance.Stop();
                             break;
                     }
 

--- a/NavUtilities continued/NavUtilLib/GlobalVariables.cs
+++ b/NavUtilities continued/NavUtilLib/GlobalVariables.cs
@@ -400,8 +400,10 @@ namespace NavUtilLib
             public static bool isLoaded = false;
             
             public static GameObject audioplayer; 
-            public static AudioSource markerAudio;
+            private static AudioSource markerAudio;
             //public static AudioSource playOnce;
+
+            private bool isPlaying = false;
 
             public static void initializeAudio()
             {
@@ -440,9 +442,41 @@ namespace NavUtilLib
                     throw;
                 }
 
-
                 isLoaded = true;
+            }
+
+            public static void PlayClick()
+            {
+                Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(Settings.getAudioPath() + "click"));
+            }
+
+            public void PlayOuter()
+            {
+                Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(Settings.getAudioPath() + "outer"));
+                this.isPlaying = true;
+            }
+
+            public void PlayMiddle()
+            {
+                Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(Settings.getAudioPath() + "middle"));
+                this.isPlaying = true;
+            }
+
+            public void PlayInner()
+            {
+                Audio.markerAudio.PlayOneShot(GameDatabase.Instance.GetAudioClip(Settings.getAudioPath() + "inner"));
+                this.isPlaying = true;
+            }
+
+            public void Stop()
+            {
+                if (this.isPlaying)
+                {
+                    Audio.markerAudio.Stop();
+                    this.isPlaying = false;
+                }
             }
         }
     }
 }
+


### PR DESCRIPTION
…that was provoking a "Matrix stack full depth reached" bug on the Unity guts on the second time you switch scenes and forward.

The first time you load a vessel things works fine, but as soon as you switch back to KSC and launch anything else, the NavUtils throws a NRE with a lot of logs from Unity complaining about "Matrix stack full depth reached". The ILS doesn't shows, and the whole UI disappears as you were pressed F-2.

I never got into this before KSP 1.7.3, but the behaviour was consistent on my rig today. Researching about that Matrix stunt, I got to a page complaining about this happening on the Editor, and disappeared when an asset was restored on the file system - so I imagined that perhaps the Stop being applied when no sound was ever played before could be the reason, and apparently I was right.

